### PR TITLE
AMI_DIR and clean_and_segment_data.sh  corrections

### DIFF
--- a/egs/ami/s5b/local/ami_ihm_data_prep.sh
+++ b/egs/ami/s5b/local/ami_ihm_data_prep.sh
@@ -27,8 +27,8 @@ odir=data/ihm/train_orig
 mkdir -p $dir
 
 # Audio data directory check
-if [ ! -d $AMI_DIR ]; then
-  echo "Error: $AMI_DIR directory does not exists."
+if [ ! -d $AMI_DIR/ ]; then
+  echo "Error: $AMI_DIR/ directory does not exists."
   exit 1;
 fi
 
@@ -40,7 +40,7 @@ fi
 
 
 # find headset wav audio files only
-find $AMI_DIR -iname '*.Headset-*.wav' | sort > $dir/wav.flist
+find $AMI_DIR/ -iname '*.Headset-*.wav' | sort > $dir/wav.flist
 n=`cat $dir/wav.flist | wc -l`
 echo "In total, $n headset files were found."
 [ $n -ne 687 ] && \

--- a/egs/ami/s5b/local/ami_ihm_scoring_data_prep.sh
+++ b/egs/ami/s5b/local/ami_ihm_scoring_data_prep.sh
@@ -25,7 +25,7 @@ odir=data/ihm/${SET}_orig
 mkdir -p $dir
 
 # Audio data directory check
-if [ ! -d $AMI_DIR ]; then
+if [ ! -d $AMI_DIR/ ]; then
   echo "Error: run.sh requires a directory argument"
   exit 1;
 fi
@@ -40,7 +40,7 @@ fi
 # the files in the corpora and filter only specific sessions
 # while building segments
 
-find $AMI_DIR -iname '*.Headset-*.wav' | sort > $dir/wav.flist
+find $AMI_DIR/ -iname '*.Headset-*.wav' | sort > $dir/wav.flist
 n=`cat $dir/wav.flist | wc -l`
 echo "In total, $n headset files were found."
 [ $n -ne 687 ] && \

--- a/egs/ami/s5b/local/ami_mdm_data_prep.sh
+++ b/egs/ami/s5b/local/ami_mdm_data_prep.sh
@@ -26,7 +26,7 @@ odir=data/$mic/train_orig
 mkdir -p $dir
 
 # Audio data directory check
-if [ ! -d $AMI_DIR ]; then
+if [ ! -d $AMI_DIR/ ]; then
   echo "Error: run.sh requires a directory argument"
   exit 1;
 fi
@@ -38,7 +38,7 @@ if [ ! -f $SEGS ]; then
 fi
 
 # find MDM mics
-find $AMI_DIR -iname "*${mic}.wav" | sort > $dir/wav.flist
+find $AMI_DIR/ -iname "*${mic}.wav" | sort > $dir/wav.flist
 
 n=`cat $dir/wav.flist | wc -l`
 echo "In total, $n headset files were found."

--- a/egs/ami/s5b/local/ami_mdm_scoring_data_prep.sh
+++ b/egs/ami/s5b/local/ami_mdm_scoring_data_prep.sh
@@ -27,7 +27,7 @@ dir=data/$mic/${SET}_orig
 mkdir -p $tmpdir
 
 # Audio data directory check
-if [ ! -d $AMI_DIR ]; then
+if [ ! -d $AMI_DIR/ ]; then
   echo "Error: run.sh requires a directory argument"
   exit 1;
 fi
@@ -39,7 +39,7 @@ if [ ! -f $SEGS ]; then
 fi
 
 # find selected mdm wav audio files only
-find $AMI_DIR -iname "*${mic}.wav" | sort > $tmpdir/wav.flist
+find $AMI_DIR/ -iname "*${mic}.wav" | sort > $tmpdir/wav.flist
 n=`cat $tmpdir/wav.flist | wc -l`
 if [ $n -ne 169 ]; then
   echo "Warning. Expected to find 169 files but found $n."

--- a/egs/ami/s5b/local/ami_sdm_data_prep.sh
+++ b/egs/ami/s5b/local/ami_sdm_data_prep.sh
@@ -32,7 +32,7 @@ odir=data/$DSET/train_orig
 mkdir -p $dir
 
 # Audio data directory check
-if [ ! -d $AMI_DIR ]; then
+if [ ! -d $AMI_DIR/ ]; then
   echo "Error: run.sh requires a directory argument"
   exit 1;
 fi
@@ -44,7 +44,7 @@ if [ ! -f $SEGS ]; then
 fi
 
 # as the sdm we treat first mic from the array
-find $AMI_DIR -iname "*.Array1-0$MICNUM.wav" | sort > $dir/wav.flist
+find $AMI_DIR/ -iname "*.Array1-0$MICNUM.wav" | sort > $dir/wav.flist
 
 n=`cat $dir/wav.flist | wc -l`
 

--- a/egs/ami/s5b/local/ami_sdm_scoring_data_prep.sh
+++ b/egs/ami/s5b/local/ami_sdm_scoring_data_prep.sh
@@ -33,7 +33,7 @@ dir=data/$DSET/${SET}_orig
 mkdir -p $tmpdir
 
 # Audio data directory check
-if [ ! -d $AMI_DIR ]; then
+if [ ! -d $AMI_DIR/ ]; then
   echo "Error: run.sh requires a directory argument"
   exit 1;
 fi
@@ -48,7 +48,7 @@ fi
 # the files in the corpora and filter only specific sessions
 # while building segments
 
-find $AMI_DIR -iname "*.Array1-0$MICNUM.wav" | sort > $tmpdir/wav.flist
+find $AMI_DIR/ -iname "*.Array1-0$MICNUM.wav" | sort > $tmpdir/wav.flist
 
 n=`cat $tmpdir/wav.flist | wc -l`
 echo "In total, $n files were found."

--- a/egs/ami/s5b/run.sh
+++ b/egs/ami/s5b/run.sh
@@ -39,8 +39,8 @@ LM=$final_lm.pr1-7
 
 # Download AMI corpus, You need around 130GB of free space to get whole data ihm+mdm,
 if [ $stage -le 0 ]; then
-  if [ -d $AMI_DIR ] && ! touch $AMI_DIR/.foo 2>/dev/null; then
-    echo "$0: directory $AMI_DIR seems to exist and not be owned by you."
+  if [ -d $AMI_DIR/ ] && ! touch $AMI_DIR/.foo 2>/dev/null; then
+    echo "$0: directory $AMI_DIR/ seems to exist and not be owned by you."
     echo " ... Assuming the data does not need to be downloaded.  Please use --stage 1 or more."
     exit 1
   fi
@@ -57,7 +57,7 @@ if [ "$base_mic" == "mdm" ]; then
   if [ $stage -le 1 ]; then
     # for MDM data, do beamforming
     ! hash BeamformIt && echo "Missing BeamformIt, run 'cd ../../../tools/; extras/install_beamformit.sh; cd -;'" && exit 1
-    local/ami_beamform.sh --cmd "$train_cmd" --nj 20 $nmics $AMI_DIR $PROCESSED_AMI_DIR
+    local/ami_beamform.sh --cmd "$train_cmd" --nj 20 $nmics $AMI_DIR/ $PROCESSED_AMI_DIR
   fi
 else
   PROCESSED_AMI_DIR=$AMI_DIR
@@ -65,9 +65,9 @@ fi
 
 # Prepare original data directories data/ihm/train_orig, etc.
 if [ $stage -le 2 ]; then
-  local/ami_${base_mic}_data_prep.sh $PROCESSED_AMI_DIR $mic
-  local/ami_${base_mic}_scoring_data_prep.sh $PROCESSED_AMI_DIR $mic dev
-  local/ami_${base_mic}_scoring_data_prep.sh $PROCESSED_AMI_DIR $mic eval
+  local/ami_${base_mic}_data_prep.sh $PROCESSED_AMI_DIR/ $mic
+  local/ami_${base_mic}_scoring_data_prep.sh $PROCESSED_AMI_DIR/ $mic dev
+  local/ami_${base_mic}_scoring_data_prep.sh $PROCESSED_AMI_DIR/ $mic eval
 fi
 
 if [ $stage -le 3 ]; then

--- a/egs/wsj/s5/steps/cleanup/clean_and_segment_data.sh
+++ b/egs/wsj/s5/steps/cleanup/clean_and_segment_data.sh
@@ -188,8 +188,12 @@ fi
 
 if [ $stage -le 9 ]; then
   # use the baseline segmentation
-  cp -rf ../s5b/exp/ihm/tri3_cleaned_work/segments exp/ihm/tri3_cleaned_work
-  cp -rf ../s5b/exp/ihm/tri3_cleaned_work/text exp/ihm/tri3_cleaned_work
+  CURRENT_DIR=$(basename $(pwd))
+  if [ "$CURRENT_DIR" != "s5b" ]
+  then
+      cp -rf ../s5b/exp/ihm/tri3_cleaned_work/segments exp/ihm/tri3_cleaned_work
+      cp -rf ../s5b/exp/ihm/tri3_cleaned_work/text exp/ihm/tri3_cleaned_work
+  fi
 fi
 
 if [ $stage -le 9 ]; then


### PR DESCRIPTION
Two corrections are made :

1.   AMI_DIR is replaced by AMI_DIR/  , because if we put / character at the end of path, find command works also for the links (which is my case, because we had to place the data into another disk)

2. clean_and_segment_data.sh line 191 is corrected which was breaking the execution of the script run.sh . What we corrected is : checking if we are in the s5b directory before executing  << cp -rf ../s5b/exp/ihm/tri3_cleaned_work/segments exp/ihm/tri3_cleaned_work >>  command